### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,9 @@ This file itself is based on [Keep a CHANGELOG](https://keepachangelog.com/en/0.
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/topolvm/pie/compare/4b825dc642cb6eb9a060e54bf8d69288fbee4904...HEAD
+## [0.1.0] - 2022-10-24
+
+This is the first release.
+
+[Unreleased]: https://github.com/topolvm/pie/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/topolvm/pie/compare/4b825dc642cb6eb9a060e54bf8d69288fbee4904...v0.1.0

--- a/charts/pie/CHANGELOG.md
+++ b/charts/pie/CHANGELOG.md
@@ -7,9 +7,4 @@ This file itself is based on [Keep a CHANGELOG](https://keepachangelog.com/en/0.
 
 ## [Unreleased]
 
-## [0.1.0] - 2022-10-24
-
-This is the first release.
-
-[Unreleased]: https://github.com/topolvm/pie/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/topolvm/pie/compare/4b825dc642cb6eb9a060e54bf8d69288fbee4904...v0.1.0
+[Unreleased]: https://github.com/topolvm/pie/compare/4b825dc642cb6eb9a060e54bf8d69288fbee4904...HEAD


### PR DESCRIPTION
Version 0.1.0 was once released at the following commit. 69cf6fc908a4b057d0840b8c8953e7d6882276c4

However, there was a mistake on this release.
This commit fix it.