### PR TITLE
enhance node selector to fix jobs or pods pending

### DIFF
--- a/charts/pie/templates/deployment.yaml
+++ b/charts/pie/templates/deployment.yaml
@@ -66,8 +66,8 @@ spec:
           {{- with .Values.controller.createProbeThreshold }}
           - "--create-probe-threshold={{ . }}"
           {{- end }}
-          {{- with .Values.controller.nodeSelectorLabel }}
-          - "--node-selector-label"
+          {{- with .Values.controller.nodeSelector }}
+          - "--node-selector"
           - "{{ . }}"
           {{- end }}
           {{- with .Values.controller.probePeriod }}

--- a/charts/pie/values.yaml
+++ b/charts/pie/values.yaml
@@ -60,4 +60,4 @@ affinity: {}
 controller:
   monitoringStorageClasses: []
   createProbeThreshold:
-  nodeSelectorLabel:
+  nodeSelector:

--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -33,7 +33,7 @@ type NodeReconciler struct {
 	namespace                string
 	controllerURL            string
 	monitoringStorageClasses []string
-	nodeSelectorLabel        map[string]string
+	nodeSelector             *metav1.LabelSelector
 	probePeriod              int
 }
 
@@ -43,7 +43,7 @@ func NewNodeReconciler(
 	namespace string,
 	controllerURL string,
 	monitoringStorageClasses []string,
-	nodeSelectorLabel map[string]string,
+	nodeSelector *metav1.LabelSelector,
 	probePeriod int,
 ) *NodeReconciler {
 	return &NodeReconciler{
@@ -52,7 +52,7 @@ func NewNodeReconciler(
 		namespace:                namespace,
 		controllerURL:            controllerURL,
 		monitoringStorageClasses: monitoringStorageClasses,
-		nodeSelectorLabel:        nodeSelectorLabel,
+		nodeSelector:             nodeSelector,
 		probePeriod:              probePeriod,
 	}
 }
@@ -307,9 +307,7 @@ func (r *NodeReconciler) createOrUpdateJob(ctx context.Context, storageClass, no
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	pred, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
-		MatchLabels: r.nodeSelectorLabel,
-	})
+	pred, err := predicate.LabelSelectorPredicate(*r.nodeSelector)
 	if err != nil {
 		return err
 	}

--- a/controllers/node_controller_test.go
+++ b/controllers/node_controller_test.go
@@ -10,6 +10,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -35,7 +36,7 @@ var _ = Describe("Node controller", func() {
 			"default",
 			"http://localhost:8082",
 			monitoringStorageClasses,
-			make(map[string]string),
+			&metav1.LabelSelector{},
 			1,
 		)
 		err = nodeReconciler.SetupWithManager(mgr)

--- a/controllers/storageclass_controller_test.go
+++ b/controllers/storageclass_controller_test.go
@@ -10,6 +10,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -35,7 +36,7 @@ var _ = Describe("StorageClass controller", func() {
 			"default",
 			"http://localhost:8082",
 			monitoringStorageClasses,
-			make(map[string]string),
+			&metav1.LabelSelector{},
 			1,
 		)
 		err = nodeReconciler.SetupWithManager(mgr)


### PR DESCRIPTION
This PR changes the option to exclude inappropriate nodes. By using this option, for example, nodes with the taint that should not be the target of pie can be excluded.