### PR TITLE
fix the occasion of getNodeNameAndStorageClass error message

### DIFF
--- a/controllers/event_controller.go
+++ b/controllers/event_controller.go
@@ -167,7 +167,9 @@ func (r *EventReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					}
 					nodeName, storageClass, err := r.getNodeNameAndStorageClass(ctx, podName)
 					if err != nil {
-						eventCtrlLogger.Error(err, "failed to name of node and storage class related to the pod", "pod", podName)
+						if !apierrors.IsNotFound(err) {
+							eventCtrlLogger.Error(err, "failed to name of node and storage class related to the pod", "pod", podName)
+						}
 						continue
 					}
 					t, ok := r.podCreatedEventTime[podName]

--- a/controllers/event_controller.go
+++ b/controllers/event_controller.go
@@ -168,7 +168,7 @@ func (r *EventReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					nodeName, storageClass, err := r.getNodeNameAndStorageClass(ctx, podName)
 					if err != nil {
 						if !apierrors.IsNotFound(err) {
-							eventCtrlLogger.Error(err, "failed to name of node and storage class related to the pod", "pod", podName)
+							eventCtrlLogger.Error(err, "failed to get node and storage class related to the pod", "pod", podName)
 						}
 						continue
 					}


### PR DESCRIPTION
This PR fixes the following error by ignoring not found error because old events may refer the deleted pod.

```
1.6686630294454665e+09  ERROR   event-reconciler        failed to name of node and storage class related to the pod     {"pod": "pie-probe-10.69.1.139-ceph-canary-block-be4f7f-27807946-tc8sw", "error": "Pod \"pie-probe-10.69.1.139-ceph-canary-block-be4f7f-27807946-tc8sw\" not found"}
github.com/topolvm/pie/controllers.(*EventReconciler).SetupWithManager.func1.1
        /work/controllers/event_controller.go:170
github.com/topolvm/pie/controllers.(*EventReconciler).SetupWithManager.func1
        /work/controllers/event_controller.go:201
```

Signed-off-by: Yuma Ogami <yuma-ogami@cybozu.co.jp>
Co-authored-by: Toshikuni Fukaya <toshikuni-fukaya@cybozu.co.jp>