### PR TITLE
observer: delete Job instead of Pod after create threshold

### DIFF
--- a/charts/pie/templates/role.yaml
+++ b/charts/pie/templates/role.yaml
@@ -76,6 +76,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - batch/v1
+  resources:
+  - jobs
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - pods

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -79,6 +79,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - batch/v1
+  resources:
+  - jobs
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - pods

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,7 +1,7 @@
 package constants
 
 const (
-	ProbePodNamePrefix        = "pie-probe"
+	ProbeNamePrefix           = "pie-probe"
 	ProbeContainerName        = "probe"
 	NodeFinalizerName         = "pie.topolvm.io/node"
 	StorageClassFinalizerName = "pie.topolvm.io/storage-class"

--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -153,7 +153,7 @@ func getCronJobName(nodeName, storageClass string) string {
 	if len(storageClass) > 18 {
 		storageClass = storageClass[:18]
 	}
-	return fmt.Sprintf("%s-%s-%s-%s", constants.ProbePodNamePrefix, nodeName, storageClass, hashedName[:6])
+	return fmt.Sprintf("%s-%s-%s-%s", constants.ProbeNamePrefix, nodeName, storageClass, hashedName[:6])
 }
 
 func (r *NodeReconciler) deleteCronJob(ctx context.Context, cronJobName string) error {

--- a/controllers/pod_controller.go
+++ b/controllers/pod_controller.go
@@ -41,7 +41,7 @@ func NewPodReconciler(
 }
 
 func isProbePodName(s string) bool {
-	return strings.HasPrefix(s, constants.ProbePodNamePrefix)
+	return strings.HasPrefix(s, constants.ProbeNamePrefix)
 }
 
 //+kubebuilder:rbac:namespace=default,groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
Pie has the ability to delete Pods that have not started within a
certain period of time. If a Pod does not start, there may be a problem,
and we do not want to have Pods being created over and over again.

In this commit, we change so that if a Pod does not start within a
certain period of time, the Jobs in the ownerReferences will be deleted
instead of the Pod.
