### PR TITLE
Fix k8s clinet.Delete() argument.

### DIFF
--- a/controllers/provision_observer.go
+++ b/controllers/provision_observer.go
@@ -108,7 +108,7 @@ func (p *provisionObserver) deleteOwnerJobOfPod(ctx context.Context, podName str
 				return err
 			}
 
-			err = p.client.Delete(ctx, &job, nil)
+			err = p.client.Delete(ctx, &job)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					continue


### PR DESCRIPTION
client.Delete() cannot accept nil as its third argument.

Signed-off-by: Yuma Ogami <yuma-ogami@cybozu.co.jp>
Co-authored-by: Toshikuni Fukaya <toshikuni-fukaya@cybozu.co.jp>