### PR TITLE
change the spec of metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,8 @@ IO latency of read.
 
 TYPE: gauge
 
-### `pie_create_probe_fast_total`
-The number of attempts that take less time between the creation of the Pod object and the creation of the container than the threshold.
-
-TYPE: counter
-
-### `pie_create_probe_slow_total`
-The number of attempts that take more time between the creation of the Pod object and the creation of the container than the threshold.
+### `pie_create_probe_total`
+The number of attempts that the creation of the Pod object and the creation of the container.
 
 TYPE: counter
 

--- a/controllers/provision_observer.go
+++ b/controllers/provision_observer.go
@@ -141,18 +141,18 @@ func (p *provisionObserver) check(ctx context.Context) {
 		if ok {
 			p.countedFlag[podName] = struct{}{}
 			if t.Sub(registeredTime) >= p.createProbeThreshold {
-				p.exporter.IncrementCreateProbeSlowCount(nodeName, storageClass)
+				p.exporter.IncrementCreateProbeCount(nodeName, storageClass, false)
 				err := p.deleteOwnerJobOfPod(ctx, podName)
 				if err != nil {
 					continue
 				}
 			} else {
-				p.exporter.IncrementCreateProbeFastCount(nodeName, storageClass)
+				p.exporter.IncrementCreateProbeCount(nodeName, storageClass, true)
 			}
 		} else {
 			if time.Since(registeredTime) >= p.createProbeThreshold {
 				p.countedFlag[podName] = struct{}{}
-				p.exporter.IncrementCreateProbeSlowCount(nodeName, storageClass)
+				p.exporter.IncrementCreateProbeCount(nodeName, storageClass, false)
 				err := p.deleteOwnerJobOfPod(ctx, podName)
 				if err != nil {
 					continue

--- a/docs/design.md
+++ b/docs/design.md
@@ -75,10 +75,10 @@ pie works as follows:
 
 ### Metrics design decision
 
-As explained in [README.md](../README.md#prometheus-metrics), metrics related to PV creation are output in the form of whether the PV creation was completed within a certain time (`create_probe_fast_total` or `create_probe_slow_total`), not the time taken for the creation.
+As explained in [README.md](../README.md#prometheus-metrics), metrics related to PV creation are output in the form of whether the PV creation was completed within a certain time (denoted as `on_time` label of `create_probe_total`), not the time taken for the creation.
 
 If you try to output the time taken to create a PV, the metrics would not be output until the PV is actually created.
 Then, if the PV cannot be created due to some problems, the metric would not be output, and
 you would not realize that there are some problems.
 
-Therefore, if the PV is not created within a certain time, `create_probe_slow_total` counter is incremented so that you can notice the problem even when the PV creation is completely stopped.
+Therefore, if the PV is not created within a certain time, `create_probe_total` counter with `on_time=false` is incremented so that you can notice the problem even when the PV creation is completely stopped.


### PR DESCRIPTION
Currently we have two kinds of metrics to track slow/fast probe. It's difficult to use from promql. So unify these two labels and distinguish slow/fast by the dedicated label.