### PR TITLE
Fix map growing

### DIFF
--- a/charts/pie/templates/role.yaml
+++ b/charts/pie/templates/role.yaml
@@ -76,7 +76,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - batch/v1
+  - batch
   resources:
   - jobs
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -79,7 +79,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - batch/v1
+  - batch
   resources:
   - jobs
   verbs:

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -3,6 +3,7 @@ package constants
 const (
 	ProbeNamePrefix           = "pie-probe"
 	ProbeContainerName        = "probe"
+	PodFinalizerName          = "pie.topolvm.io/pod"
 	NodeFinalizerName         = "pie.topolvm.io/node"
 	StorageClassFinalizerName = "pie.topolvm.io/storage-class"
 

--- a/controllers/provision_observer.go
+++ b/controllers/provision_observer.go
@@ -171,7 +171,7 @@ func (p *provisionObserver) check(ctx context.Context) {
 	}
 }
 
-//+kubebuilder:rbac:namespace=default,groups=batch/v1,resources=jobs,verbs=get;list;watch;delete
+//+kubebuilder:rbac:namespace=default,groups=batch,resources=jobs,verbs=get;list;watch;delete
 
 func (p *provisionObserver) Start(ctx context.Context) error {
 	ticker := time.NewTicker(time.Second)

--- a/controllers/provision_observer.go
+++ b/controllers/provision_observer.go
@@ -108,7 +108,8 @@ func (p *provisionObserver) deleteOwnerJobOfPod(ctx context.Context, podName str
 				return err
 			}
 
-			err = p.client.Delete(ctx, &job)
+			policy := metav1.DeletePropagationBackground
+			err = p.client.Delete(ctx, &job, &client.DeleteOptions{PropagationPolicy: &policy})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					continue

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -158,15 +158,17 @@ var _ = Describe("pie", func() {
 			}
 
 			By("checking pie_create_probe_total have on_time=true for standard SC or on_time=false for dummy SC")
-			Expect("pie_create_probe_total").Should(BeKeyOf(metricFamilies))
-			for _, metric := range metricFamilies["pie_create_probe_total"].Metric {
-				Expect(metric.Label).Should(Or(ContainElement(&standardSCLabelPair), ContainElement(&dummySCLabelPair)))
+			g.Expect("pie_create_probe_total").Should(BeKeyOf(metricFamilies))
+			metrics := metricFamilies["pie_create_probe_total"].Metric
+			g.Expect(metrics).Should(ContainElement(HaveField("Label", ContainElement(&standardSCLabelPair))))
+			g.Expect(metrics).Should(ContainElement(HaveField("Label", ContainElement(&dummySCLabelPair))))
+			for _, metric := range metrics {
 				for _, label := range metric.Label {
 					switch {
 					case reflect.DeepEqual(label, &standardSCLabelPair):
-						Expect(metric.Label).Should(ContainElement(&onTimeTrueLabelPair))
+						g.Expect(metric.Label).Should(ContainElement(&onTimeTrueLabelPair))
 					case reflect.DeepEqual(label, &dummySCLabelPair):
-						Expect(metric.Label).Should(ContainElement(&onTimeFalseLabelPair))
+						g.Expect(metric.Label).Should(ContainElement(&onTimeFalseLabelPair))
 					}
 				}
 			}


### PR DESCRIPTION
We store pods event times to maps and delete them if pods are deleted. But we misunderstood the controller-runtime delete events that do not provide object names, the deletion did not work. This PR leverages a finalizer to get object names properly.