### PR TITLE
Change builder image version to golang:1.20-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.20-bullseye as builder
 
 WORKDIR /work
 


### PR DESCRIPTION
Recently, the base image of golang:1.20 is changed to the Debian bookworm. When built with that image, pie crashes logging the following errors.

```
/pie: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /pie)
/pie: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /pie)
```

To avoid this problem, I changes the Dockerfile to use golang:1.20-bullseye as a builder image.