### PR TITLE
Stop using the `CHANGELOG.md`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,13 +41,37 @@ jobs:
           docker tag ghcr.io/topolvm/pie:${{ steps.check_version.outputs.version }} ghcr.io/topolvm/pie:${BRANCH}
           docker push ghcr.io/topolvm/pie:${BRANCH}
 
-      - name: "Create Release"
-        id: create_release
-        uses: actions/create-release@v1
+      - name: "Get previous tag"
+        id: get_previous_tag
+        run: |
+          # see https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#list-matching-references
+          RESP=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/git/matching-refs/tags/v)
+          PREV_TAG=$(echo ${RESP} | jq -r '.[].ref' | awk -F "/" '{print $3}' | \
+            grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | sort -V -r | tail -n +2 | head -n 1)
+          if [ -z "${PREV_TAG}" ]; then
+            echo "PREV_TAG is empty."
+            exit 1
+          fi
+          echo "previous_tag=${PREV_TAG}" >> ${GITHUB_OUTPUT}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release v${{ steps.check_version.outputs.version  }}
-          draft: true
-          prerelease: ${{ steps.check_version.outputs.prerelease }}
+      - name: "Create Release"
+        id: create_release
+        run: |
+          # see https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            --method POST \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/releases \
+            -f name="Release ${GITHUB_REF_NAME}" \
+            -f tag_name="${GITHUB_REF_NAME}" \
+            -f previous_tag_name="${{ steps.get_previous_tag.outputs.previous_tag }}" \
+            -F draft=true \
+            -F prerelease=${{ steps.check_version.outputs.prerelease }} \
+            -F generate_release_notes=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This file itself is based on [Keep a CHANGELOG](https://keepachangelog.com/en/0.3.0/).
 
+**Note: See the [release notes](https://github.com/topolvm/pie/releases) for changes after v0.7.2.**
+
 ## [Unreleased]
 
 ## [0.7.2] - 2023-08-17

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,87 +8,63 @@ Versioning
 
 Follow [semantic versioning 2.0.0][semver] to choose the new version number.
 
-Prepare change log entries
---------------------------
+The format of release notes
+---------------------------
 
-Add notable changes since the last release to [CHANGELOG.md](CHANGELOG.md).
-It should look like:
+In the release procedure for both the app and Helm Chart, the release note is generated automatically,
+and then it is edited manually. In this step, PRs should be classified based on [Keep a CHANGELOG](https://keepachangelog.com/en/1.1.0/).
+
+The result should look something like:
 
 ```markdown
-(snip)
-## [Unreleased]
+## What's Changed
 
 ### Added
-- Add a notable feature for users (#35)
+
+* Add a notable feature for users (#35)
 
 ### Changed
-- Change a behavior affecting users (#33)
+
+* Change a behavior affecting users (#33)
 
 ### Removed
-- Remove a feature, users action required (#39)
+
+* Remove a feature, users action required (#39)
 
 ### Fixed
-- Fix something not affecting users or a minor change (#40)
 
-### Contributors
-- @hoge
-- @foo
-
-(snip)
+* Fix something not affecting users or a minor change (#40)
 ```
 
 Bump version
 ------------
 
-1. Determine a new version number. Export it as an environment variable:
+1. Determine a new version number, and define the `VERSION` variable.
 
     ```console
-    $ VERSION=1.2.3
-    $ export VERSION
+    VERSION=1.2.3
     ```
 
-2. Make a branch for the release as follows:
+2. Add a new tag and push it.
 
     ```console
-    $ git checkout main
-    $ git pull
-    $ git checkout -b bump-$VERSION
+    git switch main
+    git pull
+    git tag v$VERSION
+    git push origin v$VERSION
     ```
 
-3. Edit `CHANGELOG.md` for the new version ([example][]).
-   The candidate of relevant PRs can be obtained by the following command.
-   ```
-   git log --merges --format="%s%x00%b" $(git tag | grep "^v" | sort -V -r | head -n 1)..main | sed -E 's|^Merge pull request #([0-9]*)[^\x0]*\x0(.*)|- \2 ([#\1](https://github.com/topolvm/pie/pull/\1))|' | tac
-   ```
-   Please remove PRs which contain changes only to the helm chart.
+3. Once a new tag is pushed, [GitHub Actions][] automatically
+   creates a draft release note for the tagged version,
+   builds a tar archive for the new release,
+   and attaches it to the release note.
+   
+   Visit https://github.com/topolvm/pie/releases to check
+   the result. 
 
-4. Commit the change and create a pull request:
-
-    ```console
-    $ git commit -a -s -m "Bump version to $VERSION"
-    $ git push -u origin bump-$VERSION
-    ```
-
-5. Merge the new pull request.
-6. Add a new tag and push it as follows:
-
-    ```console
-    $ git checkout main
-    $ git pull
-    $ git tag v$VERSION
-    $ git push origin v$VERSION
-    ```
-
-Publish GitHub release page
----------------------------
-
-Once a new tag is pushed to GitHub, [GitHub Actions][] automatically
-builds a tar archive for the new release, and uploads it to GitHub
-releases page.
-
-Visit https://github.com/topolvm/pie/releases to check
-the result. You may manually edit the page to describe the release.
-
+4. Edit the auto-generated release note
+   and remove PRs which contain changes only to the helm chart.
+   Then, publish it.
 
 Release Helm Chart
 -----------------
@@ -125,27 +101,25 @@ You must change the version of Chart.yaml when making changes to the Helm Chart.
     $ sed -r -i "s/ghcr.io\/topolvm\/pie:[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/ghcr.io\/topolvm\/pie:${APPVERSION}/g" charts/pie/Chart.yaml
     ```
 
-4. Edit `charts/pie/CHANGELOG.md` for the new version.
-   The candidate of relevant PRs can be obtained by the following command.
-   ```
-   git log --merges --format="%s%x00%b" $(git tag | grep "^pie-chart-v" | sort -V -r | head -n 1)..main | sed -E 's|^Merge pull request #([0-9]*)[^\x0]*\x0(.*)|- \2 ([#\1](https://github.com/topolvm/pie/pull/\1))|' | tac
-   ```
-   Please select PRs which contain changes to the helm chart.
-
-5. Commit the change and create a pull request:
+4. Commit the change and create a pull request:
 
     ```console
     $ git commit -a -s -m "Bump chart version to $CHARTVERSION"
     $ git push -u origin bump-chart-$CHARTVERSION
     ```
 
-6. Create new pull request and merge it.
+5. Create new pull request and merge it.
 
-7. Manually run the GitHub Actions workflow for the release.
+6. Manually run the GitHub Actions workflow for the release.
 
-    https://github.com/topolvm/pie/actions/workflows/helm-release.yaml
+   https://github.com/topolvm/pie/actions/workflows/helm-release.yaml
 
-    When you run workflow, [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action) will automatically create a GitHub Release.
+   When you run workflow, [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action) will automatically create a GitHub Release.
+
+7. Edit the auto-generated release note as follows:
+   1. Select the "Previous tag", which is in the form of "pie-chart-vX.Y.Z".
+   2. Clear the textbox, and click "Generate release notes" button.
+   3. Remove PRs which do not contain changes to the helm chart.
 
 [semver]: https://semver.org/spec/v2.0.0.html
 [example]: https://github.com/topolvm/topolvm/commit/fd7185a491ddeb860688e8efb6e7d731857b6cd0

--- a/charts/pie/CHANGELOG.md
+++ b/charts/pie/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This file itself is based on [Keep a CHANGELOG](https://keepachangelog.com/en/0.3.0/).
 
+**Note: See the [release notes](https://github.com/topolvm/pie/releases) for changes after v0.4.2.**
+
 ## [Unreleased]
 
 ## [0.4.2] - 2023-08-17


### PR DESCRIPTION
Stop using the `CHANGELOG.md`,
and use release notes instead.

Similar PR for topolvm: https://github.com/topolvm/topolvm/pull/765

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>
