### PR TITLE
Merge versions together into versions.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,7 @@
+include versions.mk
 
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/topolvm/pie:latest
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-# NOTE: the suffix .x means wildcard match so specifying the latest patch version.
-ENVTEST_K8S_VERSION = 1.27.x
-CHART_TESTING_VERSION = 3.7.1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -155,10 +152,6 @@ KUBECTL ?= kubectl
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
-
-## Tool Versions
-KUSTOMIZE_VERSION ?= v5.0.3
-CONTROLLER_TOOLS_VERSION ?= v0.12.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -22,10 +22,9 @@ Choose the next version and check the [release note](https://kubernetes.io/docs/
 
 To change the version, edit the following files.
 
-- `Makefile`
-- `README.md`
-- `e2e/Makefile`
 - `.github/workflows/e2e.yaml`
+- `README.md`
+- `versions.mk`
 
 We should also update go.mod by the following commands. Please note that Kubernetes v1 corresponds with v0 for the release tags. For example, v1.17.2 corresponds with the v0.17.2 tag.
 
@@ -42,7 +41,7 @@ $ go get sigs.k8s.io/controller-runtime@v${VERSION}
 ```
 
 Read the [`controller-tools`'s release note](https://github.com/kubernetes-sigs/controller-tools/releases), and update to the newest version that is compatible with all supported kubernetes versions. If there are breaking changes, we should decide how to manage these changes.
-To change the version, edit `Makefile`. 
+To change the version, edit `versions.mk`.
 
 #### Go
 
@@ -50,21 +49,16 @@ Choose the same version of Go [used by the latest Kubernetes](https://github.com
 
 Edit the following files.
 
-- go.mod
-- Dockerfile
+- `go.mod`
+- `Dockerfile`
 
 #### Depending tools
 
 The following tools do not depend on other software, use latest versions.
+To change their versions, edit `versions.mk`.
 - [kind](https://github.com/kubernetes-sigs/kind/releases)
-  - To change the version, edit the following files.
-    - `e2e/Makefile`
 - [helm](https://github.com/helm/helm/releases)
-  - To change the version, edit the following files.
-    - `e2e/Makefile`
 - [kustomize](https://github.com/kubernetes-sigs/kustomize/releases)
-  - To change the version, edit the following files.
-    - `Makefile`
 
 #### Depending modules
 
@@ -90,4 +84,4 @@ $ make generate
 
 #### Final check
 
-`git grep <the kubernetes version which support will be dropped>`, `git grep image:`, and `git grep -i VERSION` might help to avoid overlooking necessary changes.
+`git grep <the kubernetes version which support will be dropped>`, `git grep image:`, `git grep -i VERSION` and looking `versions.mk` might help to avoid overlooking necessary changes.

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,24 +1,13 @@
-KUBERNETES_VERSION ?= 1.27
-# The container version of kind must be with the digest.
-# ref. https://github.com/kubernetes-sigs/kind/releases
-KIND_NODE_VERSION := kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b
-KIND_CLUSTER_NAME := pie-test
-KIND_VERSION := v0.19.0
-HELM_VERSION := 3.12.0
+include ../versions.mk
 
 PROJECT_ROOT := $(shell git rev-parse --show-toplevel)
 BINDIR := $(PROJECT_ROOT)/bin
 
 CURL := curl -sSLf
-
 KIND := $(BINDIR)/kind-$(KIND_VERSION)
 HELM := $(BINDIR)/helm-$(HELM_VERSION)
 
-ifeq ($(KUBERNETES_VERSION), 1.26)
-	KIND_NODE_VERSION := kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e
-else ifeq ($(KUBERNETES_VERSION), 1.25)
-	KIND_NODE_VERSION := kindest/node:v1.25.9@sha256:c08d6c52820aa42e533b70bce0c2901183326d86dcdcbedecc9343681db45161
-endif
+KIND_CLUSTER_NAME := pie-test
 
 .PHONY: create-cluster
 create-cluster: $(KIND) $(HELM)

--- a/versions.mk
+++ b/versions.mk
@@ -1,0 +1,18 @@
+# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+# NOTE: the suffix .x means wildcard match so specifying the latest patch version.
+ENVTEST_K8S_VERSION := 1.27.x
+CHART_TESTING_VERSION := 3.7.1
+KUSTOMIZE_VERSION := v5.0.3
+CONTROLLER_TOOLS_VERSION := v0.12.0
+KUBERNETES_VERSION := 1.27
+KIND_VERSION := v0.19.0
+HELM_VERSION := 3.12.0
+
+# The container version of kind must be with the digest.
+# ref. https://github.com/kubernetes-sigs/kind/releases
+KIND_NODE_VERSION := kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b
+ifeq ($(KUBERNETES_VERSION), 1.26)
+	KIND_NODE_VERSION := kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e
+else ifeq ($(KUBERNETES_VERSION), 1.25)
+	KIND_NODE_VERSION := kindest/node:v1.25.9@sha256:c08d6c52820aa42e533b70bce0c2901183326d86dcdcbedecc9343681db45161
+endif


### PR DESCRIPTION
The pie project uses many tools and their versions are scattered in many places. It is a burden for us to update them, so we merge them into a single versoins.mk file.