### PR TITLE
Use Github App token to create chart release PR

### DIFF
--- a/.github/workflows/create-chart-update-pr.yaml
+++ b/.github/workflows/create-chart-update-pr.yaml
@@ -37,10 +37,16 @@ jobs:
           sed -r -i "s/version: [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/version: {{ inputs.chart-version }}/g" charts/pie/Chart.yaml
           sed -r -i "s/appVersion: [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/appVersion: ${{ inputs.app-version }}/g" charts/pie/Chart.yaml
           sed -r -i "s/ghcr.io\/topolvm\/pie:[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/ghcr.io\/topolvm\/pie:${{ inputs.app-version }}/g" charts/pie/Chart.yaml
+      - name: Issue an access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_PEM }}
       - name: "Create pull request"
         run: |
           git commit -a -s -m "Bump chart version to ${{ inputs.chart-version }}"
           git push --set-upstream origin bump-chart-${{ inputs.chart-version }}
           gh pr create --draft --fill
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/project-bot.yaml
+++ b/.github/workflows/project-bot.yaml
@@ -14,8 +14,8 @@ jobs:
         uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app_id: ${{ secrets.PROJECT_APP_ID }}
-          private_key: ${{ secrets.PROJECT_APP_PEM }}
+          app-id: ${{ secrets.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_PEM }}
       - name: Get project data
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
- fix deprecated notation of app-id and private-key
- use Github App token to create chart release PR
