### PR TITLE
LICENSE: fix 'APPENDIX' section not to update the Copyright boilerplate

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 The pie Authors. All rights reserved.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The description of "Copyright [yyyy] [name of copyright owner]" in the APPENDIX section of Apache License Version 2.0 is a boilerplate notice, and is not supposed to be changed to the author's copyright. This patch reverts it.