### PR TITLE
charts, test/e2e: synchronize PieProbe CRD

### DIFF
--- a/charts/pie/templates/pie.topolvm.io_pieprobes.yaml
+++ b/charts/pie/templates/pie.topolvm.io_pieprobes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: pieprobes.pie.topolvm.io
 spec:
   group: pie.topolvm.io
@@ -34,10 +34,6 @@ spec:
           spec:
             description: PieProbeSpec defines the desired state of PieProbe
             properties:
-              containerImage:
-                type: string
-              controllerUrl:
-                type: string
               monitoringStorageClass:
                 type: string
                 x-kubernetes-validations:
@@ -133,6 +129,11 @@ spec:
                 type: integer
               probeThreshold:
                 type: string
+            required:
+            - monitoringStorageClass
+            - nodeSelector
+            - probePeriod
+            - probeThreshold
             type: object
           status:
             description: PieProbeStatus defines the observed state of PieProbe

--- a/test/e2e/testdata/pieProbe.yaml
+++ b/test/e2e/testdata/pieProbe.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: e2e
 spec:
   monitoringStorageClass: standard
-  containerImage: pie:dev
-  controllerUrl: http://pie.e2e.svc:8082
   nodeSelector:
     nodeSelectorTerms:
     - matchExpressions:
@@ -25,8 +23,6 @@ metadata:
   namespace: e2e
 spec:
   monitoringStorageClass: dummy
-  containerImage: pie:dev
-  controllerUrl: http://pie.e2e.svc:8082
   nodeSelector:
     nodeSelectorTerms:
     - matchExpressions:


### PR DESCRIPTION
In pull request #101, we introduced a new custom resource called PieProbe. However, the charts/ and test/e2e/ directories were not synchronized with the auto-generated config/ directory.

This patch fixes the above probelm, by copying the latest PieProbe CRD from config/ to charts/ and updating the manifests used in the e2e tests.