### PR TITLE
fix provision_observer2 to delete failing Jobs correctly

### DIFF
--- a/internal/controller/provision_observer2.go
+++ b/internal/controller/provision_observer2.go
@@ -104,7 +104,7 @@ func (p *provisionObserver2) getNodeNameAndStorageClass(ctx context.Context, nam
 }
 
 func isProbeJob2(o metav1.OwnerReference) bool {
-	return o.Kind == "Job" && strings.HasPrefix(o.Name, constants.ProbeNamePrefix)
+	return o.Kind == "Job" && (strings.HasPrefix(o.Name, constants.MountProbeNamePrefix) || strings.HasPrefix(o.Name, constants.ProvisionProbeNamePrefix))
 }
 
 func (p *provisionObserver2) deleteOwnerJobOfPod(ctx context.Context, namespace, podName string) error {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -218,6 +218,13 @@ var _ = Describe("PieProbe resource", func() {
 				}
 			}
 		}).Should(Succeed())
+
+		// Check that failing Jobs are correctly removed.
+		Eventually(func(g Gomega) {
+			stdout, _, err := kubectl("get", "job", "-n", ns, "-l", "pie-probe=pie-probe-dummy-sc")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(stdout).Should(BeEmpty())
+		}).Should(Succeed())
 	})
 })
 


### PR DESCRIPTION
The new provision observer (provision_observer2.go) introduced in #101 tries to remove the owned jobs that are failing for a while, but it doesn't work well because it looks for them by a wrong prefix.

This PR fixes the above problem by using constants.MountProbeNamePrefix and constants.ProvisionProbeNamePrefix instead of constants.ProbeNamePrefix when the provision observer looks for the failing jobs.