### PR TITLE
pin setup-envtest to go 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,4 +171,4 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)

--- a/versions.mk
+++ b/versions.mk
@@ -1,5 +1,9 @@
 CHART_TESTING_VERSION := 3.10.1
 CONTROLLER_TOOLS_VERSION := v0.14.0
+# ENVTEST_VERSION is usually latest, but might need to be pinned from time to time.
+# Version pinning is needed due to version incompatibility between controller-runtime and setup-envtest.
+# For more information: https://github.com/kubernetes-sigs/controller-runtime/issues/2744
+ENVTEST_VERSION := bf15e44028f908c790721fc8fe67c7bf2d06a611
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 # NOTE: the suffix .x means wildcard match so specifying the latest patch version.
 ENVTEST_K8S_VERSION := 1.29.x


### PR DESCRIPTION
Currently, the CI is broken because the latest setup-envtest requires go 1.21 ([an example failed run](https://github.com/topolvm/pie/actions/runs/8479380821/job/23286909812)). This patch solves this problem by pinning setup-envtest to go 1.20.

See also:
- https://github.com/topolvm/topolvm/pull/865
- https://github.com/kubernetes-sigs/controller-runtime/issues/2744