### PR TITLE
docs: fix the VERSION variable that includes the letter 'v'

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -66,7 +66,7 @@ Read `kubernetes' go.mod`(https://github.com/kubernetes/kubernetes/blob/\<upgrad
 
 ```
 $ VERSION=<upgrading prometheus-related libraries release version>
-$ go get github.com/prometheus/client_golang@$VERSION
+$ go get github.com/prometheus/client_golang@v${VERSION}
 ```
 
 Then, please tidy up the dependencies.


### PR DESCRIPTION
The VERSION variable includes the letter 'v' only a place. So, fix the
VERSION variable that includes the letter 'v'.

Signed-off-by: Yuma Ogami <yuma-ogami@cybozu.co.jp>