### PR TITLE
fix: use at most 15 letters for node name in cronjob name

### DIFF
--- a/internal/controller/pie/pieprobe_controller.go
+++ b/internal/controller/pie/pieprobe_controller.go
@@ -514,11 +514,11 @@ func getCronJobName(kind int, nodeNamePtr *string, pieProbe *piev1alpha1.PieProb
 	if len(pieProbeName) > 10 {
 		pieProbeName = pieProbeName[:10]
 	}
-	if len(nodeName) > 11 {
-		nodeName = nodeName[:11]
+	if len(nodeName) > 15 {
+		nodeName = nodeName[:15]
 	}
-	if len(storageClass) > 14 {
-		storageClass = storageClass[:14]
+	if len(storageClass) > 12 {
+		storageClass = storageClass[:12]
 	}
 
 	if kind == ProvisionProbe {


### PR DESCRIPTION
When the current implementation decides on a cronjob name, it uses at most 11 letters for a node name. This behaviour is problematic when a node name is an IP address, which can be at most 15 (= 3*4+3) letters. This commit fixes this problem by including at most 15 letters of the node name in the cronjob name. In compensation, this commit shrinks the length of the storage class name from 14 to 12.

A mount cronjob name (at most 40 letters) consists of:

- "provision-" (10 letters)
- PieProbe resource name (at most 10 letters)
- hyphen (1 letter)
- StorageClass name (at most 12 letters)
- hyphen (1 letter)
- hash (6 letters)

A provision cronjob name (at most 52 letters) consists of:

- "mount-" (6 letters)
- PieProbe resource name (at most 10 letters)
- hyphen (1 letter)
- Node name (at most 15 letters)
- hyphen (1 letter)
- StorageClass name (at most 12 letters)
- hyphen (1 letter)
- hash (6 letters)