### PR TITLE
Support deploying provision probe or mount probe only

### DIFF
--- a/api/pie/v1alpha1/pieprobe_types.go
+++ b/api/pie/v1alpha1/pieprobe_types.go
@@ -32,6 +32,16 @@ type PieProbeSpec struct {
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="pvcCapacity is immutable"
 	PVCCapacity *resource.Quantity `json:"pvcCapacity"`
+
+	//+kubebuilder:default:=false
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="disableProvisionProbe is immutable"
+	DisableProvisionProbe bool `json:"disableProvisionProbe"`
+
+	//+kubebuilder:default:=false
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="disableMountProbes is immutable"
+	DisableMountProbes bool `json:"disableMountProbes"`
 }
 
 // PieProbeStatus defines the observed state of PieProbe

--- a/charts/pie/templates/pie.topolvm.io_pieprobes.yaml
+++ b/charts/pie/templates/pie.topolvm.io_pieprobes.yaml
@@ -39,6 +39,18 @@ spec:
           spec:
             description: PieProbeSpec defines the desired state of PieProbe
             properties:
+              disableMountProbes:
+                default: false
+                type: boolean
+                x-kubernetes-validations:
+                - message: disableMountProbes is immutable
+                  rule: self == oldSelf
+              disableProvisionProbe:
+                default: false
+                type: boolean
+                x-kubernetes-validations:
+                - message: disableProvisionProbe is immutable
+                  rule: self == oldSelf
               monitoringStorageClass:
                 type: string
                 x-kubernetes-validations:

--- a/config/crd/bases/pie.topolvm.io_pieprobes.yaml
+++ b/config/crd/bases/pie.topolvm.io_pieprobes.yaml
@@ -39,6 +39,18 @@ spec:
           spec:
             description: PieProbeSpec defines the desired state of PieProbe
             properties:
+              disableMountProbes:
+                default: false
+                type: boolean
+                x-kubernetes-validations:
+                - message: disableMountProbes is immutable
+                  rule: self == oldSelf
+              disableProvisionProbe:
+                default: false
+                type: boolean
+                x-kubernetes-validations:
+                - message: disableProvisionProbe is immutable
+                  rule: self == oldSelf
               monitoringStorageClass:
                 type: string
                 x-kubernetes-validations:


### PR DESCRIPTION
Currently, when a user deploys a PieProbe object, both of provision and
mount probes are deployed. However, under some circumstances, it is
enough to deploy either provision probes or mount probes only.

This commit supports deploying either provision probes or mount probes
only, by adding disableProvisionProbes and disableMountProbes fields to
PieProbe spec.

Signed-off-by: Ryotaro Banno <ryotaro.banno@gmail.com>