### PR TITLE
stop logging of createOrUpdateJob

### DIFF
--- a/internal/controller/pie/pieprobe_controller.go
+++ b/internal/controller/pie/pieprobe_controller.go
@@ -353,9 +353,7 @@ func (r *PieProbeReconciler) createOrUpdateJob(
 	pieProbe *piev1alpha1.PieProbe,
 	nodeName *string,
 ) error {
-	logger := log.FromContext(ctx)
-	logger.Info("createOrUpdateJob")
-	defer logger.Info("createOrUpdateJob Finished")
+	_ = log.FromContext(ctx)
 
 	cronjob := &batchv1.CronJob{}
 	cronjob.SetNamespace(pieProbe.GetNamespace())
@@ -363,7 +361,7 @@ func (r *PieProbeReconciler) createOrUpdateJob(
 
 	storageClass := pieProbe.Spec.MonitoringStorageClass
 
-	op, err := ctrl.CreateOrUpdate(ctx, r.client, cronjob, func() error {
+	_, err := ctrl.CreateOrUpdate(ctx, r.client, cronjob, func() error {
 		label := map[string]string{
 			constants.ProbeStorageClassLabelKey: storageClass,
 			constants.ProbePieProbeLabelKey:     pieProbe.GetName(),
@@ -491,9 +489,7 @@ func (r *PieProbeReconciler) createOrUpdateJob(
 	if err != nil {
 		return fmt.Errorf("failed to create CronJob: %s", getCronJobName(kind, nodeName, pieProbe))
 	}
-	if op != controllerutil.OperationResultNone {
-		logger.Info(fmt.Sprintf("CronJob successfully created: %s", getCronJobName(kind, nodeName, pieProbe)))
-	}
+
 	return nil
 }
 


### PR DESCRIPTION
The current implementation of createOrUpdateJob prints "createOrUpdate" and "createOrUpdateJob Finished" info logs every time the function runs, both before and after execution. Since this function is called repeatedly from the reconciliation loop, these logs are generated excessively. However, they don't provide any meaningful information and clutter the log readability.

This commit removes these logs to make the logs for pie much clearer.