### PR TITLE
kaizen for diskInfoImpl.Export

### DIFF
--- a/probe/exporter.go
+++ b/probe/exporter.go
@@ -46,9 +46,11 @@ func (di *diskInfoImpl) Export(metrics *DiskMetrics) error {
 		return err
 	}
 
+	var resp *http.Response
 	for retryCounter := 0; retryCounter < maxRetryCount; retryCounter++ {
-		_, err = http.Post(di.url, "application/json", bytes.NewReader(s))
+		resp, err = http.Post(di.url, "application/json", bytes.NewReader(s))
 		if err == nil {
+			_ = resp.Body.Close()
 			return nil
 		}
 		log.Printf("failed to post data: %v", err)

--- a/probe/exporter.go
+++ b/probe/exporter.go
@@ -3,6 +3,7 @@ package probe
 import (
 	"bytes"
 	"encoding/json"
+	"log"
 	"net/http"
 	"time"
 
@@ -50,6 +51,7 @@ func (di *diskInfoImpl) Export(metrics *DiskMetrics) error {
 		if err == nil {
 			return nil
 		}
+		log.Printf("failed to post data: %v", err)
 		time.Sleep(time.Second * retryIntervalSec)
 	}
 


### PR DESCRIPTION
This PR consists of two commits of kaizen for `diskInfoImpl.Export`.