### PR TITLE
run golangci-lint on CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,5 +14,6 @@ jobs:
         with:
           go-version-file: "go.mod"
       - run: make check-uncommitted
+      - run: make lint
       - run: make test
       - run: make docker-build


### PR DESCRIPTION
When I added golangci-lint in the following commit,
I forgot adding it to the GitHub workflow file.
commit: 3037de10d4c8673ec745817a1b69b3fd9387cd96

This commit fixes it.

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>
