### PR TITLE
ci: add permissions

### DIFF
--- a/.github/workflows/create-chart-update-pr.yaml
+++ b/.github/workflows/create-chart-update-pr.yaml
@@ -10,6 +10,10 @@ on:
         description: chart version (e.g. 0.1.0)
         type: string
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   create-chart-update-pr:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,8 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
 jobs:
   e2e-k8s:
     name: "e2e-k8s"

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -2,6 +2,9 @@ name: "Release Charts"
 
 on: "workflow_dispatch"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -6,6 +6,8 @@ on:
       - "charts/**"
       - "ct.yaml"
 
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - "main"
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "build"

--- a/.github/workflows/pr-labeled.yaml
+++ b/.github/workflows/pr-labeled.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
+permissions: {}
+
 jobs:
   label-do-not-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,11 @@ on:
   push:
     tags:
       - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     name: "release"

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,13 +9,14 @@ on:
   schedule:
   - cron: "30 23 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
 
     runs-on: ubuntu-slim
-    permissions:
-      issues: write
-      pull-requests: write
 
     steps:
     - uses: actions/stale@v10


### PR DESCRIPTION
Add `permissions` field to the CI workflows.

The following workflows are tested on this PR:

- e2e.yaml
- main.yaml
- pr-labeled.yaml

The following workflows are tested manually

- create-chart-update-pr.yaml
  - https://github.com/topolvm/pie/actions/runs/27121595466/job/80039825988

However, the following workflows cannot be tested (I think), so I'd like to merge them first and fix any issues later.

- helm-release.yaml
- helm.yaml
- release.yaml
- stale.yaml
