### PR TITLE
ci: create-chart-update-pr: drop permissions for pull-requests write

### DIFF
--- a/.github/workflows/create-chart-update-pr.yaml
+++ b/.github/workflows/create-chart-update-pr.yaml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   create-chart-update-pr:


### PR DESCRIPTION
`pull-requests: write` isn't necessary because the workflow issues and uses a new app token instead of `GITHUB_TOKEN`.

Test run: https://github.com/topolvm/pie/actions/runs/27127595868/job/80060114098